### PR TITLE
refactor: rename CI() to ID()

### DIFF
--- a/cienv/circleci.go
+++ b/cienv/circleci.go
@@ -23,7 +23,7 @@ func NewCircleCI(param *Param) *CircleCI {
 	}
 }
 
-func (cc *CircleCI) CI() string {
+func (cc *CircleCI) ID() string {
 	return "circleci"
 }
 

--- a/cienv/codebuild.go
+++ b/cienv/codebuild.go
@@ -22,7 +22,7 @@ func NewCodeBuild(param *Param) *CodeBuild {
 	}
 }
 
-func (cb *CodeBuild) CI() string {
+func (cb *CodeBuild) ID() string {
 	return "codebuild"
 }
 

--- a/cienv/drone.go
+++ b/cienv/drone.go
@@ -21,7 +21,7 @@ func NewDrone(param *Param) *Drone {
 	}
 }
 
-func (drone *Drone) CI() string {
+func (drone *Drone) ID() string {
 	return "drone"
 }
 

--- a/cienv/github_actions.go
+++ b/cienv/github_actions.go
@@ -40,7 +40,7 @@ func NewGitHubActions(param *Param) *GitHubActions {
 	}
 }
 
-func (gha *GitHubActions) CI() string {
+func (gha *GitHubActions) ID() string {
 	return "github-actions"
 }
 

--- a/cienv/platform.go
+++ b/cienv/platform.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Platform interface {
-	CI() string
+	ID() string
 	Match() bool
 	RepoOwner() string
 	RepoName() string
@@ -27,7 +27,7 @@ type Param struct {
 
 func Add(fn func(param *Param) Platform) {
 	p := fn(nil)
-	platformFuncs[p.CI()] = fn
+	platformFuncs[p.ID()] = fn
 }
 
 func Get(param *Param) Platform { //nolint:ireturn

--- a/cienv/platform_test.go
+++ b/cienv/platform_test.go
@@ -13,9 +13,9 @@ func TestPlatform(t *testing.T) {
 		return
 	}
 
-	t.Run("Platform.CI", func(t *testing.T) {
+	t.Run("Platform.ID", func(t *testing.T) {
 		t.Parallel()
-		if platform.CI() == "" {
+		if platform.ID() == "" {
 			t.Error("platform.CI() is empty")
 		}
 	})


### PR DESCRIPTION
## ⚠️ Breaking Change

Platform.CI() is renamed to Platform.ID()