### PR TITLE
feat: prioritize the platform `github-actions`

### DIFF
--- a/cienv/platform.go
+++ b/cienv/platform.go
@@ -31,7 +31,13 @@ func Add(fn func(param *Param) Platform) {
 }
 
 func Get(param *Param) Platform { //nolint:ireturn
-	for _, newPlatform := range platformFuncs {
+	if platformFuncs["github-actions"](param).Match() {
+		return platformFuncs["github-actions"](param)
+	}
+	for k, newPlatform := range platformFuncs {
+		if k == "github-actions" {
+			continue
+		}
 		platform := newPlatform(param)
 		if platform.Match() {
 			return platform


### PR DESCRIPTION
# WHAT

This PR implements https://github.com/suzuki-shunsuke/go-ci-env/issues/447.

The `go-ci-env` doesn't expect the Self-hosted GitHub Actions runner on any computing services besides CodeBuild so far, so this implementation is enough.

# WHY

To support the Self-hosted GitHub Actions runner on CodeBuild.
As I wrote in the Issue above, the Self-hosted GitHub Actions runner on CodeBuild includes environment variables for both CodeBuild and GitHub Actions.