### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,5 +15,8 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: read
+      id-token: write

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -1,11 +1,17 @@
 ---
 name: test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -13,6 +19,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.4'
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
           aqua_version: v2.59.1

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,5 +1,9 @@
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   path-filter:
     timeout-minutes: 10
@@ -26,4 +30,8 @@ jobs:
 
   test:
     uses: ./.github/workflows/wc-test.yaml
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      contents: read
+      id-token: write


### PR DESCRIPTION
## Overview

Introduce [Takumi Guard](https://github.com/suzuki-shunsuke/ghalint) into the CI workflows.

The `TAKUMI_GUARD_BOT_ID` secret and the `id-token: write` permission are plumbed through the reusable-workflow chain (`pull_request.yaml` → `workflow_call_test.yaml` → `wc-test.yaml`), and Takumi Guard is set up in the actual test job before any Go module is downloaded.

## Changes

### `.github/workflows/pull_request.yaml`
- Pass `secrets.TAKUMI_GUARD_BOT_ID` to the `test` job
- Add the `id-token: write` permission

### `.github/workflows/workflow_call_test.yaml`
- Declare `on.workflow_call.secrets.TAKUMI_GUARD_BOT_ID` (`required: true`)
- Pass `secrets.TAKUMI_GUARD_BOT_ID` to the `test` job and add the `contents: read` / `id-token: write` permissions

### `.github/workflows/wc-test.yaml`
- Declare `on.workflow_call.secrets.TAKUMI_GUARD_BOT_ID` (`required: true`)
- Add a `flatt-security/setup-takumi-guard-golang@v1` step right after `setup-go`, before `aqua-installer` / `golangci-lint run` / `go test`, so that Takumi Guard is set up before any Go module download
- Add the `contents: read` / `id-token: write` permissions

## Note

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)